### PR TITLE
Update gixy repository link to actively maintained fork

### DIFF
--- a/docs/awesome/nginx-resources.md
+++ b/docs/awesome/nginx-resources.md
@@ -39,7 +39,7 @@ This list is maintained by [Frederic Cambus](https://www.cambus.net). For update
 - [Nice nginx features for developers](https://alex.dzyoba.com/blog/nginx-features-for-developers/)
 - [Nice nginx features for operators](https://alex.dzyoba.com/blog/nginx-features-for-operators/)
 - [Avoiding the Top 10 NGINX Configuration Mistakes](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/)
-- [Gixy - Nginx configuration static analyzer](https://github.com/yandex/gixy)
+- [Gixy - Nginx configuration static analyzer](https://github.com/dvershinin/gixy)
 - [Nginx common configuration - Universal config and snippets](https://github.com/tldr-devops/nginx-common-configuration)
 
 ## Tutorials


### PR DESCRIPTION
The original `yandex/gixy` repository has been unmaintained since 2020.

The [`dvershinin/gixy`](https://github.com/dvershinin/gixy) fork (published as `gixy-ng` on PyPI) is actively maintained with:
- Python 3.6+ support (up to 3.13)
- Additional security checks beyond the original
- Regular updates and releases
- Modern dependency support

Official website: https://gixy.org
Documentation: https://gixy.getpagespeed.com